### PR TITLE
Remove Carp::Always dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,5 +3,4 @@ requires 'REST::Client', '>= 273';
 requires 'Crypt::JWT', '>= 0.022';
 requires 'Moo', '>= 2.003004';
 requires 'Data::UUID', '>= 1.221';
-requires 'Carp::Always', '>= 0.13';
 requires 'Throwable', '>= 0.200013';


### PR DESCRIPTION
This pull request removes the last occurrence of the previously removed `Carp::Always` dependency.