### PR TITLE
Fix incorrect package name of PurchasesManager

### DIFF
--- a/lib/plenigo/PurchasesManager.pm
+++ b/lib/plenigo/PurchasesManager.pm
@@ -1,4 +1,4 @@
-package plenigo::CustomersManager;
+package plenigo::PurchasesManager;
 
 =head1 NAME
 


### PR DESCRIPTION
This pull request fixes the incorrect package name of `PurchasesManager.pm`.