### PR TITLE
New method for cancellation status

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,17 @@
+name: Tests on Linux
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install cpanm
+      run: sudo apt-get install --no-install-recommends --yes cpanminus
+    - name: install deps
+      run: cpanm --sudo -n --installdeps .
+    - name: perl tests
+      run: prove -v -l t

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Changes for plenigo perl SDK
 
+Unreleased
+        - Added https://api.plenigo.com/#!/user/hasBoughtProductWithProducts functionality
 2.0006  2018-11-27
         - Bugfixes
         

--- a/cpanfile
+++ b/cpanfile
@@ -4,3 +4,6 @@ requires 'Crypt::JWT', '>= 0.022';
 requires 'Moo', '>= 2.003004';
 requires 'Data::UUID', '>= 1.221';
 requires 'Throwable', '>= 0.200013';
+on 'test' => sub {
+    requires 'Test::Exception';
+};

--- a/lib/plenigo/AccessRightsManager.pm
+++ b/lib/plenigo/AccessRightsManager.pm
@@ -151,6 +151,9 @@ sub willRenew {
         });
     }
     my $user_product = shift @{ $result->{userProducts} || [] } || {};
+    if (defined $user_product->{lifeTimeEnd}) {
+        return $user_product->{lifeTimeEnd} <= 0;
+    }
     if (defined $user_product->{nextRenewalDate}) {
         return $user_product->{nextRenewalDate} > 0;
     }

--- a/lib/plenigo/AccessRightsManager.pm
+++ b/lib/plenigo/AccessRightsManager.pm
@@ -46,12 +46,20 @@ use Carp qw(confess);
 use plenigo::Ex;
 use plenigo::RestClient;
 
-our $VERSION = '2.0006';
+our $VERSION = '2.0007';
 
 has configuration => (
     is       => 'ro',
-    required => 1
+    required => 1,
 );
+
+has _rest_client => (is => 'lazy',);
+
+sub _build__rest_client {
+    my $self = shift;
+    my $rest_client = plenigo::RestClient->new(configuration => $self->configuration);
+    return $rest_client;
+}
 
 =head1 METHODS
 
@@ -109,6 +117,47 @@ sub removeAccess {
     $rest_client->delete('access/' . $customer_id . '/remove', { customerId => $customer_id, productIds => @product_ids, useExternalCustomerId => $self->configuration->use_external_customer_id, testMode => $self->configuration->staging });
 
     return 1;
+}
+
+=head2 willRenew
+
+  my $truth = $access_rights->willRenew($customer_id, $product_id);
+
+Test if a customer's subscription will renew.
+
+=cut
+
+sub willRenew {
+    my ($self, $customer_id, $product_id) = @_;
+    my $rest_client = $self->_rest_client;
+    my $result = $rest_client->get(
+        'user/product/details', {
+            customerId => $customer_id,
+            productId => $product_id,
+            useExternalCustomerId => $self->configuration->use_external_customer_id,
+            testMode => $self->configuration->staging,
+        },
+    );
+    if (ref($result) ne 'HASH') {
+        plenigo::Ex->throw({
+            code => 500,
+            message => 'There was an internal error. Please try again later.',
+        });
+    }
+    if (exists $result->{error}) {
+        plenigo::Ex->throw({
+            code => 404,
+            message => $result->{error},
+        });
+    }
+    my $user_product = shift @{ $result->{userProducts} || [] } || {};
+    if (defined $user_product->{nextRenewalDate}) {
+        return $user_product->{nextRenewalDate} > 0;
+    }
+    plenigo::Ex->throw({
+        code => 500,
+        message => 'There was an internal error. Please try again later.',
+    });
 }
 
 1;

--- a/t/03_company_settings_manager.t
+++ b/t/03_company_settings_manager.t
@@ -4,10 +4,7 @@ use 5.10.0;
 use FindBin 1.51 qw( $RealBin );
 use lib $RealBin;
 
-=pod
-# integration tests must be filled with valid company data to run correctly
-
-use Test::More tests => 1;
+use Test::More skip_all => 'integration tests must be filled with valid company data to run correctly';
 use plenigo::Configuration;
 use plenigo::CompanySettings;
 

--- a/t/03_company_settings_manager.t
+++ b/t/03_company_settings_manager.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 use strict;
 use warnings;
 use 5.10.0;

--- a/t/04_access_rights_manager.t
+++ b/t/04_access_rights_manager.t
@@ -29,7 +29,7 @@ use plenigo::AccessRightsManager;
                 accessGranted => \1,
                 userProducts  => [{
                     blocked => \0,
-                    nextRenewalDate => 1582761600000,
+                    nextRenewalDate => '1582761600000',
                     productId => $args->{productId},
                 }],
             },
@@ -37,7 +37,7 @@ use plenigo::AccessRightsManager;
                 accessGranted => \1,
                 userProducts  => [{
                     blocked => \0,
-                    nextRenewalDate => 0,
+                    lifeTimeEnd => '1582761600000',
                     productId => $args->{productId},
                 }],
             },

--- a/t/04_access_rights_manager.t
+++ b/t/04_access_rights_manager.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 use strict;
 use warnings;
 use 5.10.0;

--- a/t/04_access_rights_manager.t
+++ b/t/04_access_rights_manager.t
@@ -4,28 +4,32 @@ use 5.10.0;
 use FindBin 1.51 qw( $RealBin );
 use lib $RealBin;
 
-=pod
-# integration tests must be filled with valid company data to run correctly
-
-use Test::More tests => 3;
+use Test::More;
 use plenigo::Configuration;
 use plenigo::AccessRightsManager;
 
-my $company_id = '';
-my $secret = '';
-my $plenigo_customer_id = '';
+my $company_id = $ENV{PLENIGO_COMPANY_ID} || '';
+my $secret = $ENV{PLENIGO_SECRET} || '';
+my $plenigo_customer_id = $ENV{PLENIGO_CUSTOMER_ID} || '';
 
-my $configuration = plenigo::Configuration->new(company_id => $company_id, secret => $secret, staging => 0);
+SKIP: {
+    skip 'integration tests must be filled with valid company data to run correctly', 3
+        unless $company_id && $secret;
 
-my $access_rights = plenigo::AccessRightsManager->new(configuration => $configuration);
-my %access_rights = $access_rights->hasAccess($plenigo_customer_id, ['perl_test']);
-is($access_rights{'accessGranted'}, 0, 'Check access right exists.');
+    my $configuration = plenigo::Configuration->new(company_id => $company_id, secret => $secret, staging => 0);
 
-$access_rights->addAccess($plenigo_customer_id, (details => [{productId => 'perl_test'}]));
-%access_rights = $access_rights->hasAccess($plenigo_customer_id, ['perl_test']);
-is($access_rights{'accessGranted'}, 1, 'Check if access right exists after addition.');
+    my $access_rights = plenigo::AccessRightsManager->new(configuration => $configuration);
+    my %access_rights = $access_rights->hasAccess($plenigo_customer_id, ['perl_test']);
+    is($access_rights{'accessGranted'}, 0, 'Check access right exists.');
 
-$access_rights->removeAccess($plenigo_customer_id, ['perl_test']);
-%access_rights = $access_rights->hasAccess($plenigo_customer_id, ['perl_test']);
-is($access_rights{'accessGranted'}, 0, 'Check if access right exists after removal.');
-=cut
+    $access_rights->addAccess($plenigo_customer_id, (details => [{productId => 'perl_test'}]));
+    %access_rights = $access_rights->hasAccess($plenigo_customer_id, ['perl_test']);
+    is($access_rights{'accessGranted'}, 1, 'Check if access right exists after addition.');
+
+    $access_rights->removeAccess($plenigo_customer_id, ['perl_test']);
+    %access_rights = $access_rights->hasAccess($plenigo_customer_id, ['perl_test']);
+    is($access_rights{'accessGranted'}, 0, 'Check if access right exists after removal.');
+}
+
+
+done_testing;

--- a/t/04_access_rights_manager.t
+++ b/t/04_access_rights_manager.t
@@ -4,9 +4,89 @@ use 5.10.0;
 use FindBin 1.51 qw( $RealBin );
 use lib $RealBin;
 
+use Test::Exception;
 use Test::More;
 use plenigo::Configuration;
 use plenigo::AccessRightsManager;
+
+{
+    package Mock::Client;
+    use Moo;
+    has configuration => (is => 'ro');
+
+    sub get {
+        my ($self, $path, $args) = @_;
+
+        return $self->_user_product_details($path, $args)
+            if ($path eq 'user/product/details');
+    }
+
+    sub _user_product_details {
+        my ($self, $path, $args) = @_;
+        my $test_cases = {
+            'bad_data' => { },
+            'customer_123_will_renew' => {
+                accessGranted => \1,
+                userProducts  => [{
+                    blocked => \0,
+                    nextRenewalDate => 1582761600000,
+                    productId => $args->{productId},
+                }],
+            },
+            'customer_456_will_not_renew' => {
+                accessGranted => \1,
+                userProducts  => [{
+                    blocked => \0,
+                    nextRenewalDate => 0,
+                    productId => $args->{productId},
+                }],
+            },
+        };
+        return (exists $test_cases->{ $args->{customerId} }) ?
+            $test_cases->{ $args->{customerId} } :
+            { error => 'User is not allowed to access the product requested.' };
+    }
+    1;
+}
+
+sub make_candidate {
+    my $configuration = plenigo::Configuration->new(
+        company_id => 'company_id',
+        secret => 'secret',
+        staging => 0,
+        @_,
+    );
+    my $access_rights = plenigo::AccessRightsManager->new(
+        configuration => $configuration,
+        _rest_client => Mock::Client->new,
+    );
+}
+
+subtest 'AccessRightsManager' => sub {
+    my $access_rights = make_candidate;
+    isa_ok($access_rights, 'plenigo::AccessRightsManager');
+};
+
+subtest 'willRenew' => sub {
+    my $access_rights = make_candidate;
+    can_ok($access_rights, ('willRenew'));
+    is(
+        $access_rights->willRenew('customer_123_will_renew', 'product_123'),
+        1,
+        'customer will renew'
+    );
+    is(
+        $access_rights->willRenew('customer_456_will_not_renew', 'product_123'),
+        '',
+        'customer will not renew'
+    );
+    throws_ok {
+        $access_rights->willRenew('no_such_customer', 'product_123')
+    } 'plenigo::Ex', 'error thrown for unknown customer';
+    throws_ok {
+        $access_rights->willRenew('bad_data', 'product_123')
+    } 'plenigo::Ex', 'error thrown for bad response';
+};
 
 my $company_id = $ENV{PLENIGO_COMPANY_ID} || '';
 my $secret = $ENV{PLENIGO_SECRET} || '';

--- a/t/05_products_manager.t
+++ b/t/05_products_manager.t
@@ -4,10 +4,7 @@ use 5.10.0;
 use FindBin 1.51 qw( $RealBin );
 use lib $RealBin;
 
-=pod
-# integration tests must be filled with valid company data to run correctly
-
-use Test::More tests => 2;
+use Test::More skip_all => 'integration tests must be filled with valid company data to run correctly';
 use plenigo::Configuration;
 use plenigo::ProductsManager;
 
@@ -23,4 +20,3 @@ is($product{'id'}, $product_id, 'Get product details for a single product.');
 
 my %product_list = $products->getAllProducts(0, 10);
 is($product_list{'pageNumber'}, 0, 'Get product details for all products.');
-=cut

--- a/t/05_products_manager.t
+++ b/t/05_products_manager.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 use strict;
 use warnings;
 use 5.10.0;

--- a/t/06_login_manager.t
+++ b/t/06_login_manager.t
@@ -4,10 +4,7 @@ use 5.10.0;
 use FindBin 1.51 qw($RealBin);
 use lib $RealBin;
 
-=pod
-# integration tests must be filled with valid company data to run correctly
-
-use Test::More tests => 2;
+use Test::More skip_all => 'integration tests must be filled with valid company data to run correctly';
 use plenigo::Configuration;
 use plenigo::LoginManager;
 use Try::Tiny;
@@ -25,4 +22,3 @@ my %customer_details = $loginManager->verifyLoginData($customer_email, $customer
 is($customer_details{'userId'}, $customer_id, 'Check customer\'s log in data via API.');
 
 ok($loginManager->createLoginTokens($customer_id), 'Create login tokens for a given user.');
-=cut

--- a/t/06_login_manager.t
+++ b/t/06_login_manager.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 use strict;
 use warnings;
 use 5.10.0;

--- a/t/07_customer_manager.t
+++ b/t/07_customer_manager.t
@@ -4,10 +4,7 @@ use 5.10.0;
 use FindBin 1.51 qw($RealBin);
 use lib $RealBin;
 
-=pod
-# integration tests must be filled with valid company data to run correctly
-
-use Test::More tests => 1;
+use Test::More skip_all => 'integration tests must be filled with valid company data to run correctly';
 use plenigo::Configuration;
 use plenigo::CustomersManager;
 use Try::Tiny;
@@ -21,4 +18,3 @@ my $customers_manager = plenigo::CustomersManager->new(configuration => $configu
 my $customer_mail_part = 'perltest+' . time();
 my %customer_details = $customers_manager->registerCustomer($customer_mail_part . '@example.com', 'DE', undef, 'MALE', 'Mike', 'Miller', 0, 0);
 ok($customers_manager->editCustomer($customer_details{'customerId'}, $customerMailPart . '_changed@example.com'), 'Customers email changed successfully.');
-=cut

--- a/t/07_customer_manager.t
+++ b/t/07_customer_manager.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 use strict;
 use warnings;
 use 5.10.0;

--- a/t/08_purchases_manager.t
+++ b/t/08_purchases_manager.t
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 use strict;
 use warnings;
 use 5.10.0;

--- a/t/08_purchases_manager.t
+++ b/t/08_purchases_manager.t
@@ -4,10 +4,7 @@ use 5.10.0;
 use FindBin 1.51 qw($RealBin);
 use lib $RealBin;
 
-=pod
-# integration tests must be filled with valid company data to run correctly
-
-use Test::More tests => 1;
+use Test::More skip_all => 'integration tests must be filled with valid company data to run correctly';
 use plenigo::Configuration;
 use plenigo::CustomersManager;
 use plenigo::PurchasesManager;
@@ -24,4 +21,3 @@ my %customer_details = $customers_manager->registerCustomer($customer_mail_part 
 
 my $purchases_manager = plenigo::PurchasesManager->new(configuration => $configuration);
 ok($purchases_manager->getCustomerSubscriptions($customer_details{'customerId'}), 'Subscriptions of the customer returned successfully.');
-=cut


### PR DESCRIPTION
This pull request adds

* a github action which runs the tests
* a method to retrieve the cancellation status from https://api.plenigo.com/#!/user/hasBoughtProductWithProducts